### PR TITLE
Updated docs link to point to docs.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Keyboard utilities for the wayland-client library. Mainly handling keymaps with 
 
 # Documentation
 
-[Available online](http://vberger.github.io/wayland-kbd/wayland_kbd/)
+[Available online](https://docs.rs/wayland-kbd/)


### PR DESCRIPTION
The documentation is now out of date with the recent 0.9.0 update, so I updated the readme to point to the most up-to-date version on docs.rs