### PR TITLE
Update to memmap 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ travis-ci = { repository = "Smithay/wayland-kbd" }
 [dependencies]
 bitflags = "1.0"
 lazy_static = "0.2"
-memmap = "0.4"
+memmap = "0.6"
 wayland-client = "0.11"
 dlib = "0.4"
 

--- a/src/mapped_keyboard.rs
+++ b/src/mapped_keyboard.rs
@@ -1,6 +1,6 @@
 use ffi::{self, xkb_state_component};
 use ffi::XKBCOMMON_HANDLE as XKBH;
-use memmap::{Mmap, Protection};
+use memmap::MmapOptions;
 use std::env;
 use std::ffi::CString;
 use std::fs::File;
@@ -277,11 +277,11 @@ impl KbState {
     }
 
     unsafe fn init_with_fd(&mut self, fd: RawFd, size: usize) {
-        let map = Mmap::open_with_offset(&File::from_raw_fd(fd), Protection::Read, 0, size).unwrap();
+        let map = MmapOptions::new().len(size).map(&File::from_raw_fd(fd)).unwrap();
 
         let xkb_keymap = (XKBH.xkb_keymap_new_from_string)(
             self.xkb_context,
-            map.ptr() as *const _,
+            map.as_ptr() as *const _,
             ffi::xkb_keymap_format::XKB_KEYMAP_FORMAT_TEXT_V1,
             ffi::xkb_keymap_compile_flags::XKB_KEYMAP_COMPILE_NO_FLAGS,
         );


### PR DESCRIPTION
`memmap` 0.6.0 introduces major API changes in anticipation of a 1.0
release. See https://github.com/danburkert/memmap-rs/releases/tag/0.6.0
for more information. CC danburkert/memmap-rs#33.